### PR TITLE
bugfix: Replace div with fragment on context provider

### DIFF
--- a/src/components/Curtains.js
+++ b/src/components/Curtains.js
@@ -143,10 +143,10 @@ function CurtainsWrapper(props) {
     validProps.children = null;
 
     return (
-        <div>
+        <>
             {props.children}
             <div {...validProps} ref={container} />
-        </div>
+        </>
     );
 }
 


### PR DESCRIPTION
This would stop polluting the DOM when using react-curtains