### PR TITLE
Fixes Example onRender => onError

### DIFF
--- a/curtains.md
+++ b/curtains.md
@@ -64,7 +64,7 @@ function MainCurtains() {
             pixelRatio={Math.min(1.5, window.devicePixelRatio)}
             antialias={false}
             
-            onRender={onCurtainsError}
+            onError={onCurtainsError}
             onRender={onCurtainsRender}
         >
             <App />


### PR DESCRIPTION
Just a minor fix in the readme.
```
            onRender={onCurtainsError}
            onRender={onCurtainsRender}
```
The first `onRender` is supposed to be `onError`.